### PR TITLE
Add ARM64 installation target

### DIFF
--- a/HotKeysVSIX/source.extension.vsixmanifest
+++ b/HotKeysVSIX/source.extension.vsixmanifest
@@ -14,6 +14,9 @@
 		<InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Community">
 			<ProductArchitecture>amd64</ProductArchitecture>
 		</InstallationTarget>
+		<InstallationTarget Version="[17.0,)" Id="Microsoft.VisualStudio.Community">
+			<ProductArchitecture>arm64</ProductArchitecture>
+		</InstallationTarget>
 	</Installation>
 	<Dependencies>
 		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
I added an ARM64 installation target to the vsix manifest. I confirmed that it works on a Parallels Windows 11 VM.